### PR TITLE
Add option to load textures on demand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Rider
+.idea/

--- a/DVCargoSwapMod/Main.cs
+++ b/DVCargoSwapMod/Main.cs
@@ -140,13 +140,15 @@ namespace DVCargoSwapMod
                         // Check if file already read for skin texture.
                         if (!skinTexturePaths[brandName].ContainsKey(fileName))
                             // Add file path
-                            skinTexturePaths[brandName].Add(fileName, skinFilePath);
+                            skinTexturePaths[brandName][fileName] = skinFilePath;
 
                         if (settings.loadOnDemand)
                             continue;
 
                         // Load texture into memory
-                        skinTextures[brandName].Add(fileName, LoadTextureFromDisk(skinFilePath));
+                        if (!skinTextures.ContainsKey(brandName))
+                            skinTextures[brandName] = new Dictionary<string, Texture2D>();
+                        skinTextures[brandName][fileName] = LoadTextureFromDisk(skinFilePath);
                     }
                 }
             }

--- a/DVCargoSwapMod/Settings.cs
+++ b/DVCargoSwapMod/Settings.cs
@@ -1,0 +1,19 @@
+﻿using UnityModManagerNet;
+
+namespace DVCargoSwapMod
+{
+    public class Settings : UnityModManager.ModSettings, IDrawable 
+    {
+
+        [Draw(Label = "Load Textures on Demand (requires restart)", Type = DrawType.Toggle)]
+        public bool loadOnDemand;
+
+        public override void Save(UnityModManager.ModEntry entry)
+        {
+            Save(this, entry);
+        }
+
+        public void OnChange() { }
+
+    }
+}


### PR DESCRIPTION
Adds an option (disabled by default) to load all textures on demand rather than on startup to reduce memory usage.
This does cause a lag spike when spawning in cars, which is why it's toggleable.
If #1 gets merged I'd be happy to re-write this to be compatible as it would suit it very nicely.